### PR TITLE
Fix typo on huiskeuring form

### DIFF
--- a/backend/lib/routes/huiskeuringen.php
+++ b/backend/lib/routes/huiskeuringen.php
@@ -119,7 +119,7 @@ function register_huiskeuringen_routes(FastRoute\RouteCollector $r, \Lib\Databas
                 case 0: return "Noord (Drenthe / Friesland / Groningen)";
                 case 1: return "Oost (Gelderland / Overijssel / Flevoland)";
                 case 2: return "West (Utrecht / Zuid-Holland / Noord-Holland)";
-                case 3: return "Zuid (Limburg / Noord-Braband / Zeeland / België)";
+                case 3: return "Zuid (Limburg / Noord-Brabant / Zeeland / België)";
                 case -1: return "Overig - Zie opmerking";
             }
         }

--- a/frontend/src/app/member-page/huiskeuringen-page/add-huiskeuring-page/add-huiskeuring-page.component.html
+++ b/frontend/src/app/member-page/huiskeuringen-page/add-huiskeuring-page/add-huiskeuring-page.component.html
@@ -31,7 +31,7 @@
                 <mat-option [value]="0">Noord (Drenthe / Friesland / Groningen)</mat-option>
                 <mat-option [value]="1">Oost (Gelderland / Overijssel / Flevoland)</mat-option>
                 <mat-option [value]="2">West (Utrecht / Zuid-Holland / Noord-Holland)</mat-option>
-                <mat-option [value]="3">Zuid (Limburg / Noord-Braband / Zeeland / België)</mat-option>
+                <mat-option [value]="3">Zuid (Limburg / Noord-Brabant / Zeeland / België)</mat-option>
                 <mat-option [value]="-1">Overig - Zie opmerking</mat-option>
             </mat-select>
             <mat-error *ngIf="formGroup.controls.region.hasError('required')">Verplicht</mat-error>


### PR DESCRIPTION
Fix typo Noord-Braband to Noord-Brabant on huiskeuring form